### PR TITLE
Fix contributing.md url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ Programming is not a required skill. Whatever you've seen about open source and 
 
 It is more important to the community that you are able to contribute.
 
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/.github/CONTRIBUTING.md) file.


### PR DESCRIPTION
Minor fix : contributing.md had been moved in logstash repo. 
