### PR TITLE
Bump plugin API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+---
 sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+- bundle exec rspec spec
+jdk: oraclejdk8
+before_install: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+ - Bumped up logstash-core-plugin-api dependency to allow installation with Logstash 5.
+
 ## 2.0.6
  - doc: Documentation improvements.
 
@@ -11,7 +14,7 @@
  - internal,deps: New dependency requirements for logstash-core for the 5.0 release
 
 ## 2.0.0
- - internal: Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - internal: Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - internal,deps: Dependency on logstash-core update to 2.0
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Contributors:
 * Aaron Mildenstein (untergeek)
 * David R Soller (3ygun)
 * Jordan Sissel (jordansissel)
+* Joshua Spence (joshuaspence)
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)

--- a/lib/logstash/filters/prune.rb
+++ b/lib/logstash/filters/prune.rb
@@ -14,19 +14,19 @@ require "logstash/namespace"
 #
 # Usage help:
 # To specify a exact field name or value use the regular expression syntax `^some_name_or_value$`.
-# Example usage: Input data `{ "msg":"hello world", "msg_short":"hw" }` 
+# Example usage: Input data `{ "msg":"hello world", "msg_short":"hw" }`
 # [source,ruby]
-#     filter { 
-#       %PLUGIN% { 
+#     filter {
+#       %PLUGIN% {
 #         whitelist_names => [ "msg" ]
 #       }
 #     }
 # Allows both `"msg"` and `"msg_short"` through.
-# 
+#
 # While:
 # [source,ruby]
-#     filter { 
-#       %PLUGIN% { 
+#     filter {
+#       %PLUGIN% {
 #         whitelist_names => ["^msg$"]
 #       }
 #     }
@@ -44,9 +44,9 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
   config :interpolate, :validate => :boolean, :default => false
 
   # Include only fields only if their names match specified regexps, default to empty list which means include everything.
-  # [source,ruby] 
-  #     filter { 
-  #       %PLUGIN% { 
+  # [source,ruby]
+  #     filter {
+  #       %PLUGIN% {
   #         whitelist_names => [ "method", "(referrer|status)", "${some}_field" ]
   #       }
   #     }
@@ -54,8 +54,8 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
 
   # Exclude fields whose names match specified regexps, by default exclude unresolved `%{field}` strings.
   # [source,ruby]
-  #     filter { 
-  #       %PLUGIN% { 
+  #     filter {
+  #       %PLUGIN% {
   #         blacklist_names => [ "method", "(referrer|status)", "${some}_field" ]
   #       }
   #     }
@@ -64,8 +64,8 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
   # Include specified fields only if their values match one of the supplied regular expressions.
   # In case field values are arrays, each array item is matched against the regular expressions and only matching array items will be included.
   # [source,ruby]
-  #     filter { 
-  #       %PLUGIN% { 
+  #     filter {
+  #       %PLUGIN% {
   #         whitelist_values => [ "uripath", "/index.php",
   #                               "method", "(GET|POST)",
   #                               "status", "^[^2]" ]
@@ -76,8 +76,8 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
   # Exclude specified fields if their values match one of the supplied regular expressions.
   # In case field values are arrays, each array item is matched against the regular expressions and matching array items will be excluded.
   # [source,ruby]
-  #     filter { 
-  #       %PLUGIN% { 
+  #     filter {
+  #       %PLUGIN% {
   #         blacklist_values => [ "uripath", "/index.php",
   #                               "method", "(HEAD|OPTIONS)",
   #                               "status", "^[^2]" ]
@@ -101,7 +101,7 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
 
   public
   def filter(event)
-    
+
 
     hash = event.to_hash
 
@@ -161,9 +161,10 @@ class LogStash::Filters::Prune < LogStash::Filters::Base
 
     fields_to_remove.each do |field|
       if field.is_a?(Hash)
-        hash[field[:key]] = hash[field[:key]] - field[:values]
+        event.set(field[:key], hash[field[:key]] - field[:values])
       else
         hash.delete(field)
+        event.remove(field)
       end
     end
 

--- a/logstash-filter-prune.gemspec
+++ b/logstash-filter-prune.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-prune'
-  s.version         = '2.0.6'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The prune filter is for pruning event data from fields based on whitelist/blacklist of field names or their values (names and values can also be regular expressions)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/filters/prune_spec.rb
+++ b/spec/filters/prune_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Filters::Prune, :if => false  do
         prune { }
       }
     CONFIG
-    
+
     sample(
       "firstname"    => "Borat",
       "lastname"     => "Sagdiyev",
@@ -28,15 +28,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == "Borat"
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == "Borat Sagdiyev"
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == "Somethere in Kazakhstan"
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == "200"
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == "Borat"
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == "Borat Sagdiyev"
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == "Somethere in Kazakhstan"
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == "200"
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -49,7 +49,7 @@ describe LogStash::Filters::Prune, :if => false  do
         }
       }
     CONFIG
-    
+
     sample(
       "firstname"    => "Borat",
       "lastname"     => "Sagdiyev",
@@ -61,15 +61,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == "Borat"
-      insist { subject["lastname"] } == nil
-      insist { subject["fullname"] } == nil
-      insist { subject["country"] } == nil
-      insist { subject["location"] } == nil
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == "200"
-      insist { subject["Borat_saying"] } == nil
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == "Borat"
+      insist { subject.get("lastname") } == nil
+      insist { subject.get("fullname") } == nil
+      insist { subject.get("country") } == nil
+      insist { subject.get("location") } == nil
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == "200"
+      insist { subject.get("Borat_saying") } == nil
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -83,7 +83,7 @@ describe LogStash::Filters::Prune, :if => false  do
         }
       }
     CONFIG
-    
+
     sample(
       "firstname"    => "Borat",
       "lastname"     => "Sagdiyev",
@@ -95,15 +95,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == "Borat"
-      insist { subject["lastname"] } == nil
-      insist { subject["fullname"] } == nil
-      insist { subject["country"] } == nil
-      insist { subject["location"] } == nil
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == "200"
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == "Borat"
+      insist { subject.get("lastname") } == nil
+      insist { subject.get("fullname") } == nil
+      insist { subject.get("country") } == nil
+      insist { subject.get("location") } == nil
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == "200"
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -128,15 +128,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == nil
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == "Borat Sagdiyev"
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == "Somethere in Kazakhstan"
-      insist { subject["hobby"] } == nil
-      insist { subject["status"] } == nil
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
-      insist { subject["%{hmm}"] } == "doh"
+      insist { subject.get("firstname") } == nil
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == "Borat Sagdiyev"
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == "Somethere in Kazakhstan"
+      insist { subject.get("hobby") } == nil
+      insist { subject.get("status") } == nil
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("%{hmm}") } == "doh"
     end
   end
 
@@ -162,15 +162,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == nil
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == "Borat Sagdiyev"
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == "Somethere in Kazakhstan"
-      insist { subject["hobby"] } == nil
-      insist { subject["status"] } == nil
-      insist { subject["Borat_saying"] } == nil
-      insist { subject["%{hmm}"] } == "doh"
+      insist { subject.get("firstname") } == nil
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == "Borat Sagdiyev"
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == "Somethere in Kazakhstan"
+      insist { subject.get("hobby") } == nil
+      insist { subject.get("status") } == nil
+      insist { subject.get("Borat_saying") } == nil
+      insist { subject.get("%{hmm}") } == "doh"
     end
   end
 
@@ -201,25 +201,25 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == "Borat"
+      insist { subject.get("firstname") } == "Borat"
 
       # TODO(sissel): According to the config above, this should be nil because
       # it is not in the list of whitelisted fields, but we expect it to be
       # "Sagdiyev" ? I am confused.
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == nil
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == nil
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == "200"
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == nil
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == nil
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == "200"
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
 
       # TODO(sissel): Contrary to the 'lastname' check, we expect %{hmm} field
-      # to be nil because it is not whitelisted, yes? Contradictory insists 
+      # to be nil because it is not whitelisted, yes? Contradictory insists
       # here. I don't know what the intended behavior is... Seems like
       # whitelist means 'anything not here' but since this test is written
       # confusingly, I dont' know how to move forward.
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -249,15 +249,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == "Borat"
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == "Borat Sagdiyev"
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == nil
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == "200"
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == "Borat"
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == "Borat Sagdiyev"
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == nil
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == "200"
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -286,15 +286,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == nil
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == "Borat Sagdiyev"
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == "Somethere in Kazakhstan"
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == nil
-      insist { subject["Borat_saying"] } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == nil
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == "Borat Sagdiyev"
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == "Somethere in Kazakhstan"
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == nil
+      insist { subject.get("Borat_saying") } == "Cloud is not ready for enterprise if is not integrate with single server running Active Directory."
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -324,15 +324,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "Borat_saying" => "Cloud is not ready for enterprise if is not integrate with single server running Active Directory.",
       "%{hmm}"       => "doh"
     ) do
-      insist { subject["firstname"] } == nil
-      insist { subject["lastname"] } == "Sagdiyev"
-      insist { subject["fullname"] } == nil
-      insist { subject["country"] } == "Kazakhstan"
-      insist { subject["location"] } == "Somethere in Kazakhstan"
-      insist { subject["hobby"] } == "Cloud"
-      insist { subject["status"] } == nil
-      insist { subject["Borat_saying"] } == nil
-      insist { subject["%{hmm}"] } == nil
+      insist { subject.get("firstname") } == nil
+      insist { subject.get("lastname") } == "Sagdiyev"
+      insist { subject.get("fullname") } == nil
+      insist { subject.get("country") } == "Kazakhstan"
+      insist { subject.get("location") } == "Somethere in Kazakhstan"
+      insist { subject.get("hobby") } == "Cloud"
+      insist { subject.get("status") } == nil
+      insist { subject.get("Borat_saying") } == nil
+      insist { subject.get("%{hmm}") } == nil
     end
   end
 
@@ -354,10 +354,10 @@ describe LogStash::Filters::Prune, :if => false  do
       "status" => [ "100", "200", "300", "400", "500" ],
       "error"  => [ "This is foolish" , "Need smthing smart too" ]
     ) do
-      insist { subject["blah"] } == "foo"
-      insist { subject["error"] } == nil
-      insist { subject["xxx"] } == [ "1 2 3", "3 4 5" ]
-      insist { subject["status"] } == [ "100", "200", "300" ]
+      insist { subject.get("blah") } == "foo"
+      insist { subject.get("error") } == nil
+      insist { subject.get("xxx") } == [ "1 2 3", "3 4 5" ]
+      insist { subject.get("status") } == [ "100", "200", "300" ]
     end
   end
 
@@ -379,15 +379,15 @@ describe LogStash::Filters::Prune, :if => false  do
       "status" => [ "100", "200", "300", "400", "500" ],
       "error"  => [ "This is foolish", "Need smthing smart too" ]
     ) do
-      insist { subject["blah"] } == "foo"
-      insist { subject["error"] } == [ "This is foolish", "Need smthing smart too" ]
-      insist { subject["xxx"] } == nil
-      insist { subject["status"] } == [ "400", "500" ]
+      insist { subject.get("blah") } == "foo"
+      insist { subject.get("error") } == [ "This is foolish", "Need smthing smart too" ]
+      insist { subject.get("xxx") } == nil
+      insist { subject.get("status") } == [ "400", "500" ]
     end
   end
 
   describe "whitelist field values with interpolation on fields witn array values" do
- 
+
     config <<-CONFIG
       filter {
         prune {
@@ -405,10 +405,10 @@ describe LogStash::Filters::Prune, :if => false  do
       "status" => [ "100", "200", "300", "400", "500" ],
       "error"  => [ "This is foolish" , "Need smthing smart too" ]
     ) do
-      insist { subject["blah"] } == "foo"
-      insist { subject["error"] } == [ "This is foolish" ]
-      insist { subject["xxx"] } == [ "1 2 3", "3 4 5" ]
-      insist { subject["status"] } == [ "100", "200", "300" ]
+      insist { subject.get("blah") } == "foo"
+      insist { subject.get("error") } == [ "This is foolish" ]
+      insist { subject.get("xxx") } == [ "1 2 3", "3 4 5" ]
+      insist { subject.get("status") } == [ "100", "200", "300" ]
     end
   end
 
@@ -431,10 +431,10 @@ describe LogStash::Filters::Prune, :if => false  do
       "status" => [ "100", "200", "300", "400", "500" ],
       "error"  => [ "This is foolish" , "Need smthing smart too" ]
     ) do
-      insist { subject["blah"] } == "foo"
-      insist { subject["error"] } == [ "Need smthing smart too" ]
-      insist { subject["xxx"] } == nil
-      insist { subject["status"] } == [ "400", "500" ]
+      insist { subject.get("blah") } == "foo"
+      insist { subject.get("error") } == [ "Need smthing smart too" ]
+      insist { subject.get("xxx") } == nil
+      insist { subject.get("status") } == [ "400", "500" ]
     end
   end
 


### PR DESCRIPTION
Fixes #17. Bumps `logstash-core-plugin-api` in order to allow installation on Logstash 5. It seems that this plugin is already compatible with the new `Event` API, so the only thing that is required for Logstash 5 compatibility is bumping the plugin API version.

These changes were basically copied from [logstash-filter-alter](https://github.com/logstash-plugins/logstash-filter-alter), specifically [1b9c73d7b7cd681fcf73afe52e01e57cb24e30fd](https://github.com/logstash-plugins/logstash-filter-alter/commit/1b9c73d7b7cd681fcf73afe52e01e57cb24e30fd), [0ba3edd85e752fa2a2ac50c2833cb3e83da4fa08](https://github.com/logstash-plugins/logstash-filter-alter/commit/0ba3edd85e752fa2a2ac50c2833cb3e83da4fa08) and [fe6fe57e491630c48d380de8e2c3bda6aa34ad18](https://github.com/logstash-plugins/logstash-filter-alter/commit/fe6fe57e491630c48d380de8e2c3bda6aa34ad18).